### PR TITLE
Landing page links

### DIFF
--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -20,3 +20,4 @@ rewrite "^/docs/SDKs/rust$" "/docs/reference/sdks/rust" permanent;
 rewrite "^/docs/getting-started/connect-freighter-wallet$" "/docs/reference/freighter" permanent;
 rewrite "^/docs/common-interfaces/token$" "/docs/reference/interfaces/token-interface" permanent;
 rewrite "^/docs/how-to-guides/tokens$" "/docs/advanced-tutorials/tokens" permanent;
+rewrite "^/docs/getting-started/create-an-app$" "/docs/getting-started/hello-world" permanent;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -193,29 +193,29 @@ const GettingStarted = () => (
         <GettingStartedCard
           index="1."
           title="Hello World"
-          subtitle="Create your first Soroban contract."
+          subtitle="Create your first Soroban project with a smart contract and front-end app."
           href="/docs/getting-started/hello-world"
         />
 
         <GettingStartedCard
           index="2."
-          title="Storing Data"
-          subtitle="Write a simple Soroban contract that stores and retrieves data."
-          href="/docs/getting-started/storing-data"
-        />
-
-        <GettingStartedCard
-          index="3."
           title="Deploy to Testnet"
           subtitle="Deploy and invoke your contracts on Testnet."
           href="/docs/getting-started/deploy-to-testnet"
         />
 
         <GettingStartedCard
+          index="3."
+          title="Storing Data"
+          subtitle="Write a simple Soroban contract that stores and retrieves data."
+          href="/docs/getting-started/storing-data"
+        />
+
+        <GettingStartedCard
           index="4."
           title="Create an App"
-          subtitle="Build a front-end app to interact with your Soroban contracts."
-          href="/docs/getting-started/create-an-app"
+          subtitle="Expand your front-end app to interact with more complex Soroban contracts."
+          href="/docs/getting-started/deploy-incrementor"
         />
 
         <GettingStartedCard


### PR DESCRIPTION
Changing the landing page to better reflect the new structure of the getting started section. Also adding an nginx redirect for the old "create an app" page that's being removed.